### PR TITLE
Added callback function attribute to call outside of the directive to return image data

### DIFF
--- a/app/angular/directive.js
+++ b/app/angular/directive.js
@@ -1,5 +1,5 @@
 /* global Webcam */
-(function() {
+(function(angular, window, undefined) {
     'use strict';
 
     angular
@@ -197,4 +197,4 @@
         }
     }
 
-})();
+})(angular,window);

--- a/app/angular/directive.js
+++ b/app/angular/directive.js
@@ -1,5 +1,5 @@
 /* global Webcam */
-(function(angular, window, undefined) {
+(function(window, angular, undefined) {
     'use strict';
 
     angular
@@ -197,4 +197,4 @@
         }
     }
 
-})(angular,window);
+})(window, angular);

--- a/app/angular/directive.js
+++ b/app/angular/directive.js
@@ -1,9 +1,9 @@
 /* global Webcam */
-(function(angular) {
+(function() {
     'use strict';
 
     angular
-        .module('camera')
+        .module('camera',[])
         .directive('ngCamera', directive);
 
     directive.$inject = ['$q', '$timeout'];
@@ -26,7 +26,8 @@
                 'cropWidth': '@',
                 'imageFormat': '@',
                 'jpegQuality': '@',
-                'snapshot': '='
+                'snapshot': '=',
+                'callback':'='
             },
             // 'templateUrl': '/angular/ng-camera.html',
             'template': ['<div class="ng-camera">',
@@ -169,6 +170,10 @@
 
                         Webcam.snap(function(data_uri) {
                             scope.snapshot = data_uri;
+                            console.log('image captured');
+                            if(scope.callback!==undefined){
+                                scope.callback(scope.snapshot)
+                            }
                         });
                     });
                 } else {
@@ -178,6 +183,10 @@
 
                     Webcam.snap(function(data_uri) {
                         scope.snapshot = data_uri;
+                        console.log('image captured');
+                        if(scope.callback!==undefined){
+                            scope.callback(scope.snapshot)
+                        }
                     });
                 }
             };
@@ -188,4 +197,4 @@
         }
     }
 
-})(angular);
+})();


### PR DESCRIPTION
Outer callback specified to return image data right after capturing to avoid explicit watcher on model in controllers where used this directive.
In my case it's done to get image data and allow to store them in array of captured images outside the directive.
//example callback in controller implementation
   vm.images=[];
   vm.recievePhoto=function(photo){ 
      vm.images.push(photo); 
 }
also updated to run with angular 1.5 because in previous version i got error, can't load module.
